### PR TITLE
make console command changes in respect to time backwards compatible

### DIFF
--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -32,11 +32,13 @@ let pp_since_count ppf = function
 type console_cmd = [
   | `Console_add
   | `Console_subscribe of since_count
+  | `Old_console_subscribe of since_count
 ]
 
 let pp_console_cmd ppf = function
   | `Console_add -> Fmt.string ppf "console add"
   | `Console_subscribe ts -> Fmt.pf ppf "console subscribe %a" pp_since_count ts
+  | `Old_console_subscribe ts -> Fmt.pf ppf "console subscribe %a" pp_since_count ts
 
 type stats_cmd = [
   | `Stats_add of string * int * (string * string) list
@@ -130,11 +132,14 @@ let pp ~verbose ppf = function
 
 type data = [
   | `Console_data of Ptime.t * string
+  | `Utc_console_data of Ptime.t * string
   | `Stats_data of Stats.t
 ]
 
 let pp_data ppf = function
   | `Console_data (ts, line) ->
+    Fmt.pf ppf "console %a: %s" (Ptime.pp_rfc3339 ()) ts line
+  | `Utc_console_data (ts, line) ->
     Fmt.pf ppf "console %a: %s" (Ptime.pp_rfc3339 ()) ts line
   | `Stats_data stats -> Fmt.pf ppf "stats: %a" Stats.pp stats
 

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -20,6 +20,7 @@ type since_count = [ `Since of Ptime.t | `Count of int ]
 type console_cmd = [
   | `Console_add
   | `Console_subscribe of since_count
+  | `Old_console_subscribe of since_count
 ]
 
 type stats_cmd = [
@@ -67,6 +68,7 @@ val pp : verbose:bool -> t Fmt.t
 
 type data = [
   | `Console_data of Ptime.t * string
+  | `Utc_console_data of Ptime.t * string
   | `Stats_data of Stats.t
 ]
 

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -550,7 +550,7 @@ let console_subscribe_v4 () =
       (Vmm_commands.header ~version:`AV4 (n_o_s "foo"))
       hdr;
     match cmd with
-    | `Command `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Command `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console_subscribe, got %a"
              (Vmm_commands.pp_wire ~verbose:true) w
 
@@ -569,7 +569,7 @@ let console_subscribe_v4_2 () =
       (Vmm_commands.header ~version:`AV4 (n_o_s "foo.bar"))
       hdr;
     match cmd with
-    | `Command `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Command `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console_subscribe, got %a"
              (Vmm_commands.pp_wire ~verbose:true) w
 
@@ -588,7 +588,7 @@ let console_subscribe_v5 () =
       (Vmm_commands.header ~version:`AV5 (n_o_s "foo"))
       hdr;
     match cmd with
-    | `Command `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Command `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console_subscribe, got %a"
              (Vmm_commands.pp_wire ~verbose:true) w
 
@@ -607,7 +607,7 @@ let console_subscribe_v5_2 () =
       (Vmm_commands.header ~version:`AV5 (n_o_s "foo.bar"))
       hdr;
     match cmd with
-    | `Command `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Command `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console_subscribe, got %a"
              (Vmm_commands.pp_wire ~verbose:true) w
 
@@ -643,7 +643,7 @@ HUBeGB+KSdPOX8zc8taDCQ==
     Alcotest.check test_version "version is 4" `AV4 version;
     Alcotest.(check bool "pols is empty" true (pols = []));
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 
@@ -676,7 +676,7 @@ HUBeGB+KSdPOX8zc8taDCQ==
     Alcotest.check test_version "version is 4" `AV4 version;
     Alcotest.(check bool "pols is empty" true (pols = []));
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 
@@ -714,7 +714,7 @@ s2bwQQncdiUHfYEPbuMIo7WxjT0WBw==
     let path, _pol = List.hd pols in
     Alcotest.check test_path "path is sub" (p_o_s "sub") path;
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 
@@ -747,7 +747,7 @@ HUBeGB+KSdPOX8zc8taDCQ==
     Alcotest.check test_version "version is 5" `AV5 version;
     Alcotest.(check bool "pols is empty" true (pols = []));
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 
@@ -780,7 +780,7 @@ HUBeGB+KSdPOX8zc8taDCQ==
     Alcotest.check test_version "version is 5" `AV5 version;
     Alcotest.(check bool "pols is empty" true (pols = []));
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 
@@ -818,7 +818,7 @@ BgMrZXADQQAZXTUICXOZCD1lFuRKi+zT0qQ2n0+AjluPM4Q+PUVjmqfLqau/2KHc
     let path, _pol = List.hd pols in
     Alcotest.check test_path "path is subv5" (p_o_s "subv5") path;
     match command with
-    | `Console_cmd `Console_subscribe `Count 20 -> ()
+    | `Console_cmd `Old_console_subscribe `Count 20 -> ()
     | _ -> Alcotest.failf "expected console subscribe command, got %a"
              (Vmm_commands.pp ~verbose:true) command
 

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -93,6 +93,7 @@ let handle chain =
     (* we only allow some commands via certificate *)
     match wire with
     | `Console_cmd (`Console_subscribe _)
+    | `Console_cmd (`Old_console_subscribe _)
     | `Stats_cmd `Stats_subscribe
     | `Unikernel_cmd _
     | `Policy_cmd `Policy_info


### PR DESCRIPTION
previously, an old client subscribed to a console, but then received generalized_time timestamps (instead of utc_time).

now, this is cleaner: the old client will indicate that they need utc_time timestamp.

discovered by @PizieDust