### PR TITLE
Influx/metrics: fix typo (cow_faul[t]s), avoid empty tag name for root domain

### DIFF
--- a/daemon/albatross_influx.ml
+++ b/daemon/albatross_influx.ml
@@ -110,7 +110,7 @@ module P = struct
         "tsize", i64 mem.tsize ;
         "dsize", i64 mem.dsize ;
         "ssize", i64 mem.ssize ;
-        "cow_fauls", string_of_int mem.cow ;
+        "cow_faults", string_of_int mem.cow ;
         "runtime", i64 mem.runtime ;
         "uptime", Printf.sprintf "%f" uptime ;
       ]

--- a/daemon/albatrossd_utils.ml
+++ b/daemon/albatrossd_utils.ml
@@ -33,8 +33,11 @@ let init_influx name data =
         | Some socket ->
           let tag = process name in
           let datas = Metrics.SM.fold (fun src (tags, data) acc ->
-              let name = Metrics.Src.name src in
-              Metrics_influx.encode_line_protocol (tag :: tags) data name :: acc)
+              match Metrics.Data.fields data with
+              | [] -> acc
+              | _ ->
+                let name = Metrics.Src.name src in
+                Metrics_influx.encode_line_protocol (tag :: tags) data name :: acc)
               (get_cache ()) []
           in
           let datas = String.concat "" datas in

--- a/src/vmm_resources.ml
+++ b/src/vmm_resources.ml
@@ -79,7 +79,9 @@ let unikernel_metrics =
 
 let report_vms t name =
   let rec doit path =
-    let str = Name.path_to_string path in
+    let str =
+      if Name.is_root_path path then ":" else Name.path_to_string path
+    in
     Metrics.add unikernel_metrics (fun x -> x str) (fun d -> d (t, path));
     if Name.is_root_path path then () else doit (Name.parent_path path)
   in


### PR DESCRIPTION
Also avoid reporting empty measurements

I can see on our mirage host:
```bash
Jul  1 12:44:32 infra-2 telegraf[86143]: 2024-07-01T12:44:32Z E! [inputs.socket_listener] Error in plugin: parsing error: metric parse error: expected field at 1:24: "kinfo_mem,vm=albatross "
Jul  1 12:44:32 infra-2 telegraf[86143]: 2024-07-01T12:44:32Z E! [inputs.socket_listener] Error in plugin: parsing error: metric parse error: expected tag at 1:36: "vmm-unikernels,vm=albatross,domain= attached\\ used\\ block=0i,unattached\\ used\\ block=0i,total\\ used\\ block=0i,running\\ unikernels=4i,used\\ memory=1216i"
```

I still don't fully understand how the `kinfo_mem,vm=albatross ` comes into play. But protecting the albatross daemon to report empty measurements may be a good idea in any case.