### PR TITLE
add support to log via syslog for daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ write their standard output to.
 from all running unikernels.
 
 `Albatross-tls-endpoint` listens on a TCP port, or uses systemd socket activation, or
-via inetd, and proxies requests from remote clients to the respective daemons described
+via inetd (remember to add `--syslog` when using `--inetd` to log via syslog),
+and proxies requests from remote clients to the respective daemons described
 above. It enforces client authentication, and uses the common names of the client
 certificate chain as the administrative domain. The policies are embedded in CA
 certificates, and the command is embedded in the leaf certificate.

--- a/albatross.opam
+++ b/albatross.opam
@@ -40,6 +40,7 @@ depends: [
   "solo5-elftool" {>= "0.3"}
   "owee" {>= "0.4"}
   "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -1218,7 +1218,7 @@ let destroy_cmd =
      `P "Destroy a unikernel."]
   in
   let term =
-    Term.(term_result (const destroy $ Albatross_cli.setup_log $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const destroy $ (Albatross_cli.setup_log (const false)) $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "destroy" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1230,7 +1230,7 @@ let restart_cmd =
      `P "Restarts a unikernel."]
   in
   let term =
-    Term.(term_result (const restart $ Albatross_cli.setup_log $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const restart $ (Albatross_cli.setup_log (const false)) $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "restart" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1242,7 +1242,7 @@ let remove_policy_cmd =
      `P "Removes a policy."]
   in
   let term =
-    Term.(term_result (const remove_policy $ Albatross_cli.setup_log $ opt_path $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const remove_policy $ (Albatross_cli.setup_log (const false)) $ opt_path $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "remove-policy" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1254,7 +1254,7 @@ let info_cmd =
      `P "Shows information about unikernels."]
   in
   let term =
-    Term.(term_result (const info_ $ Albatross_cli.setup_log $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const info_ $ (Albatross_cli.setup_log (const false)) $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "info" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1266,7 +1266,7 @@ let get_cmd =
      `P "Downloads a unikernel image from albatross to disk."]
   in
   let term =
-    Term.(term_result (const get $ Albatross_cli.setup_log $ compress_level $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const get $ (Albatross_cli.setup_log (const false)) $ compress_level $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "get" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1278,7 +1278,7 @@ let policy_cmd =
      `P "Shows information about active policies."]
   in
   let term =
-    Term.(term_result (const info_policy $ Albatross_cli.setup_log $ opt_path $  dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const info_policy $ (Albatross_cli.setup_log (const false)) $ opt_path $  dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "policy" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1290,7 +1290,7 @@ let add_policy_cmd =
      `P "Adds a policy."]
   in
   let term =
-    Term.(term_result (const add_policy $ Albatross_cli.setup_log $ vms $ mem $ cpus $ opt_block_size $ bridge $ path $  dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const add_policy $ (Albatross_cli.setup_log (const false)) $ vms $ mem $ cpus $ opt_block_size $ bridge $ path $  dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "add-policy" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1302,7 +1302,7 @@ let create_cmd =
      `P "Creates a unikernel."]
   in
   let term =
-    Term.(term_result (const create $ Albatross_cli.setup_log $ force $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level $ restart_on_fail $ exit_code $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const create $ (Albatross_cli.setup_log (const false)) $ force $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level $ restart_on_fail $ exit_code $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "create" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1314,7 +1314,7 @@ let console_cmd =
      `P "Shows console output of a unikernel."]
   in
   let term =
-    Term.(term_result (const console $ Albatross_cli.setup_log $ since $ count $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const console $ (Albatross_cli.setup_log (const false)) $ since $ count $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "console" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1326,7 +1326,7 @@ let stats_subscribe_cmd =
      `P "Shows statistics of unikernel."]
   in
   let term =
-    Term.(term_result (const stats_subscribe $ Albatross_cli.setup_log $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const stats_subscribe $ (Albatross_cli.setup_log (const false)) $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "stats" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1338,7 +1338,7 @@ let stats_remove_cmd =
      `P "Removes statistics of unikernel."]
   in
   let term =
-    Term.(term_result (const stats_remove $ Albatross_cli.setup_log $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const stats_remove $ (Albatross_cli.setup_log (const false)) $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "stats-remove" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1350,7 +1350,7 @@ let stats_add_cmd =
      `P "Add unikernel to statistics gathering."]
   in
   let term =
-    Term.(term_result (const stats_add $ Albatross_cli.setup_log $ vmm_dev $ pid_req0 $ bridge_taps $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const stats_add $ (Albatross_cli.setup_log (const false)) $ vmm_dev $ pid_req0 $ bridge_taps $ opt_vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "stats-add" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1362,7 +1362,7 @@ let block_info_cmd =
      `P "Block device information."]
   in
   let term =
-    Term.(term_result (const block_info $ Albatross_cli.setup_log $ opt_block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const block_info $ (Albatross_cli.setup_log (const false)) $ opt_block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "block" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1374,7 +1374,7 @@ let block_create_cmd =
      `P "Create of a block device."]
   in
   let term =
-    Term.(term_result (const block_create $ Albatross_cli.setup_log $ block_size $ compress_level $ opt_block_data $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const block_create $ (Albatross_cli.setup_log (const false)) $ block_size $ compress_level $ opt_block_data $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "create-block" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1386,7 +1386,7 @@ let block_set_cmd =
      `P "Set data to a block device."]
   in
   let term =
-    Term.(term_result (const block_set $ Albatross_cli.setup_log $ compress_level $ block_data $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const block_set $ (Albatross_cli.setup_log (const false)) $ compress_level $ block_data $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "set-block" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1398,7 +1398,7 @@ let block_dump_cmd =
      `P "Dump data of a block device."]
   in
   let term =
-    Term.(term_result (const block_dump $ Albatross_cli.setup_log $ compress_level $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const block_dump $ (Albatross_cli.setup_log (const false)) $ compress_level $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "dump-block" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1410,7 +1410,7 @@ let block_destroy_cmd =
      `P "Destroy a block device."]
   in
   let term =
-    Term.(term_result (const block_destroy $ Albatross_cli.setup_log $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const block_destroy $ (Albatross_cli.setup_log (const false)) $ block_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "destroy-block" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1422,7 +1422,7 @@ let update_cmd =
      `P "Check and update a unikernel from the binary repository."]
   in
   let term =
-    Term.(const update $ Albatross_cli.setup_log $ http_host $ dryrun $ compress_level $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir)
+    Term.(const update $ (Albatross_cli.setup_log (const false)) $ http_host $ dryrun $ compress_level $ vm_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir)
   and info = Cmd.info "update" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1437,7 +1437,7 @@ let inspect_dump_cmd =
     [`S "DESCRIPTION";
      `P "Inspects an albatross dump file."]
   in
-  let term = Term.(const inspect_dump $ Albatross_cli.setup_log $ file $ Albatross_cli.dbdir)
+  let term = Term.(const inspect_dump $ (Albatross_cli.setup_log (const false)) $ file $ Albatross_cli.dbdir)
   and info = Cmd.info "inspect-dump" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1457,7 +1457,7 @@ let cert_cmd =
      `P "Establishes a TLS handshake to a remote albatross server, executes the command of the client certificate, and outputs the result. "]
   in
   let term =
-    Term.(term_result (const cert $ Albatross_cli.setup_log $ destination $ server_ca $ client_cert $ client_key))
+    Term.(term_result (const cert $ (Albatross_cli.setup_log (const false)) $ destination $ server_ca $ client_cert $ client_key))
   and info = Cmd.info "certificate" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1497,7 +1497,7 @@ let generate_cmd =
      `P "Generates a certificate authority."]
   in
   let term =
-    Term.(const generate $ Albatross_cli.setup_log $ nam $ db $ days $ sname $ sday $ pub_key_type)
+    Term.(const generate $ (Albatross_cli.setup_log (const false)) $ nam $ db $ days $ sname $ sday $ pub_key_type)
   and info = Cmd.info "generate" ~doc ~man
   in
   Cmd.v info term
@@ -1517,7 +1517,7 @@ let sign_cmd =
      `P "Signs the certificate signing request."]
   in
   let term =
-    Term.(const sign_main $ Albatross_cli.setup_log $ db $ cacert $ key $ csr $ days)
+    Term.(const sign_main $ (Albatross_cli.setup_log (const false)) $ db $ cacert $ key $ csr $ days)
   and info = Cmd.info "sign" ~doc ~man
   in
   Cmd.v info term
@@ -1527,7 +1527,7 @@ let help_cmd =
     let doc = "The topic to get help on. `topics' lists the topics." in
     Arg.(value & pos 0 (some string) None & info [] ~docv:"TOPIC" ~doc)
   in
-  Term.(ret (const help $ Albatross_cli.setup_log $ Arg.man_format $ Term.choice_names $ topic))
+  Term.(ret (const help $ (Albatross_cli.setup_log (const false)) $ Arg.man_format $ Term.choice_names $ topic))
 
 let cmds = [
   policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/command-line/dune
+++ b/command-line/dune
@@ -3,4 +3,4 @@
  (public_name albatross.cli)
  (wrapped false)
  (modules albatross_cli)
- (libraries albatross albatross.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty))
+ (libraries albatross albatross.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty logs-syslog.unix))

--- a/daemon/albatross_console.ml
+++ b/daemon/albatross_console.ml
@@ -216,7 +216,7 @@ let cmd =
         fifo the unikernel is writing to.";
   ] in
   let term =
-    Term.(term_result (const jump $ Albatross_cli.setup_log $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir))
+    Term.(term_result (const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir))
   and info = Cmd.info "albatross-console" ~version:Albatross_cli.version ~doc ~man
   in
   Cmd.v info term

--- a/daemon/albatross_influx.ml
+++ b/daemon/albatross_influx.ml
@@ -313,7 +313,7 @@ let cmd =
         statistics and pushes them via TCP to influxdb";
   ] in
   let term =
-    Term.(term_result (const run_client $ Albatross_cli.setup_log $ Albatrossd_utils.influx $ opt_vm_name $ drop_label $ Albatross_cli.tmpdir))
+    Term.(term_result (const run_client $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.influx $ opt_vm_name $ drop_label $ Albatross_cli.tmpdir))
   and info = Cmd.info "albatross-influx" ~version:Albatross_cli.version ~doc ~man
   in
   Cmd.v info term

--- a/daemon/albatross_stats.ml
+++ b/daemon/albatross_stats.ml
@@ -136,7 +136,7 @@ let cmd =
         (only supported on FreeBSD)."
   ] in
   let term =
-    Term.(term_result (const jump $ Albatross_cli.setup_log $ Albatrossd_utils.systemd_socket_activation $ interval $ gather_bhyve $ Albatrossd_utils.influx $ Albatross_cli.tmpdir))
+    Term.(term_result (const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.systemd_socket_activation $ interval $ gather_bhyve $ Albatrossd_utils.influx $ Albatross_cli.tmpdir))
   and info = Cmd.info "albatross-stats" ~version:Albatross_cli.version ~doc ~man
   in
   Cmd.v info term

--- a/daemon/albatross_tls_endpoint.ml
+++ b/daemon/albatross_tls_endpoint.ml
@@ -166,7 +166,7 @@ let ip =
   Arg.(value & opt ip_c Ipaddr.(V6 V6.unspecified) & info [ "ip" ] ~doc)
 
 let inetd =
-  let doc = "Inetd mode" in
+  let doc = "Inetd mode. Be sure to use `--syslog` (or `--quiet` to disable logging)" in
   Arg.(value & flag & info [ "inetd" ] ~doc)
 
 let cmd =
@@ -181,7 +181,7 @@ let cmd =
   ] in
   let term =
     Term.(
-      const jump $ Albatross_cli.setup_log $ cacert $ cert $ key
+      const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ cacert $ cert $ key
       $ ip
       $ Albatrossd_utils.port_or_socket ~default_port:1025
       $ Albatross_cli.tmpdir

--- a/daemon/albatross_tls_endpoint.ml
+++ b/daemon/albatross_tls_endpoint.ml
@@ -101,7 +101,12 @@ let handle tls =
         (Vmm_commands.header ~version name, reply) >|= fun _ ->
       ()
 
-let jump _ cacert cert priv_key ip port_or_socket tmpdir inetd =
+let jump _ cacert cert priv_key ip port_or_socket tmpdir inetd syslog =
+  if inetd then
+    if syslog || Logs.level () = None then
+      ()
+    else
+      exit 3;
   Sys.(set_signal sigpipe Signal_ignore);
   Albatross_cli.set_tmpdir tmpdir;
   let handle config fd =
@@ -185,7 +190,7 @@ let cmd =
       $ ip
       $ Albatrossd_utils.port_or_socket ~default_port:1025
       $ Albatross_cli.tmpdir
-      $ inetd)
+      $ inetd $ Albatrossd_utils.syslog)
   and info = Cmd.info "albatross-tls-endpoint" ~version:Albatross_cli.version ~doc ~man in
   Cmd.v info term
 

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -257,7 +257,7 @@ let cmd =
       creation and attaching tap devices to bridges."
   ] in
   let term =
-    Term.(const jump $ Albatross_cli.setup_log $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir $ Albatross_cli.dbdir)
+    Term.(const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir $ Albatross_cli.dbdir)
   and info = Cmd.info "albatrossd" ~version:Albatross_cli.version ~doc ~man
   in
   Cmd.v info term

--- a/daemon/albatrossd_utils.ml
+++ b/daemon/albatrossd_utils.ml
@@ -70,8 +70,8 @@ let systemd_socket_activation =
     Arg.(value & flag & info [ "systemd-socket-activation" ] ~doc)
 
 let syslog =
-  let doc = "Pass this flag when syslog should be used for logging" in
-  Arg.(value & flag & info [ "syslog" ] ~doc)
+  let doc = "Pass this flag when syslog should be used for logging e.g. when using inetd." in
+  Arg.(value & flag & info [ "syslog" ] ~doc ~docs:"LOGGING OPTIONS")
 
 let port_or_socket ~default_port =
   let open Term in

--- a/daemon/albatrossd_utils.ml
+++ b/daemon/albatrossd_utils.ml
@@ -69,6 +69,10 @@ let systemd_socket_activation =
     let doc = "Pass this flag when systemd socket activation is being used" in
     Arg.(value & flag & info [ "systemd-socket-activation" ] ~doc)
 
+let syslog =
+  let doc = "Pass this flag when syslog should be used for logging" in
+  Arg.(value & flag & info [ "syslog" ] ~doc)
+
 let port_or_socket ~default_port =
   let open Term in
   let port =

--- a/packaging/FreeBSD/MANIFEST
+++ b/packaging/FreeBSD/MANIFEST
@@ -77,7 +77,7 @@ messages [
      and server.key into /usr/local/etc/albatross, add this to /etc/inetd.conf:
 
         blackjack  stream  tcp     nowait  albatross \
-          /usr/local/libexec/albatross/alabtross-tls-endpoint \
+          /usr/local/libexec/albatross/albatross-tls-endpoint \
           albatross-tls-endpoint --inetd \
           /usr/local/etc/albatross/cacert.pem \
           /usr/local/etc/albatross/server.pem \

--- a/packaging/FreeBSD/MANIFEST
+++ b/packaging/FreeBSD/MANIFEST
@@ -78,7 +78,7 @@ messages [
 
         blackjack  stream  tcp     nowait  albatross \
           /usr/local/libexec/albatross/albatross-tls-endpoint \
-          albatross-tls-endpoint --inetd \
+          albatross-tls-endpoint --inetd --syslog \
           /usr/local/etc/albatross/cacert.pem \
           /usr/local/etc/albatross/server.pem \
           /usr/local/etc/albatross/server.key

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -36,7 +36,7 @@ let jump () =
 open Cmdliner
 
 let cmd =
-  let term = Term.(term_result (const jump $ Albatross_cli.setup_log))
+  let term = Term.(term_result (const jump $ (Albatross_cli.setup_log (const false))))
   and info = Cmd.info "albatross-client-gen" ~version:Albatross_cli.version
   in
   Cmd.v info term


### PR DESCRIPTION
This is especially useful for albatross-tls-endpoint in inetd mode, where stdout is occupied with client communication

Fixes #176