### PR TITLE
Store the policies next to the unikernels on disk

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -814,17 +814,23 @@ let inspect_dump _ name dbdir =
   | Error (`Msg msg) ->
     Logs.err (fun m -> m "error while reading dump file: %s" msg);
     Cli_failed
-  | Ok data -> match Vmm_asn.unikernels_of_str data with
+  | Ok data -> match Vmm_asn.state_of_str data with
     | Error (`Msg msg) ->
       Logs.err (fun m -> m "couldn't parse dump file: %s" msg);
       Cli_failed
-    | Ok unikernels ->
-      let all = Vmm_trie.all unikernels in
-      Logs.app (fun m -> m "parsed %d unikernels:" (List.length all));
+    | Ok (unikernels, policies) ->
+      let uniks = Vmm_trie.all unikernels in
+      Logs.app (fun m -> m "parsed %u unikernels:" (List.length uniks));
       List.iter (fun (name, unik) ->
           Logs.app (fun m -> m "%a: %a" Vmm_core.Name.pp name
                        Vmm_core.Unikernel.pp_config unik))
-        all;
+        uniks;
+      let ps = Vmm_trie.all policies in
+      Logs.app (fun m -> m "parsed %u policies:" (List.length ps));
+      List.iter (fun (name, p) ->
+          Logs.app (fun m -> m "%a: %a" Vmm_core.Name.pp name
+                       Vmm_core.Policy.pp p))
+        ps;
       Success
 
 let cert () dst server_ca cert key =

--- a/src/vmm_asn.mli
+++ b/src/vmm_asn.mli
@@ -17,5 +17,5 @@ val of_cert_extension :
   string -> (Vmm_commands.version * Vmm_commands.t, [> `Msg of string ]) result
 val to_cert_extension : Vmm_commands.t -> string
 
-val unikernels_to_str : Unikernel.config Vmm_trie.t -> string
-val unikernels_of_str : string -> (Unikernel.config Vmm_trie.t, [> `Msg of string ]) result
+val state_to_str : Unikernel.config Vmm_trie.t -> Policy.t Vmm_trie.t -> string
+val state_of_str : string -> (Unikernel.config Vmm_trie.t * Policy.t Vmm_trie.t, [> `Msg of string ]) result

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -39,6 +39,8 @@ val handle_command : 'a t -> Vmm_commands.wire ->
 
 val killall : 'a t -> (unit -> 'b * 'a) -> 'a t * 'b list
 
-val restore_unikernels : unit -> (Unikernel.config Vmm_trie.t, [> `Msg of string ]) result
+val restore_state : unit -> (Unikernel.config Vmm_trie.t * Policy.t Vmm_trie.t, [> `Msg of string ]) result
 
-val dump_unikernels : 'a t -> unit
+val dump_state : 'a t -> unit
+
+val restore_policies : 'a t -> Policy.t Vmm_trie.t -> ('a t, [> `Msg of string ]) result

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -29,7 +29,7 @@ let unikernels =
   ins "bar:my.nice.unikernel" u2 t
 
 let jump () =
-  let data = Vmm_asn.unikernels_to_str unikernels in
+  let data = Vmm_asn.state_to_str unikernels Vmm_trie.empty in
   print_endline (Base64.encode_string data);
   Ok ()
 

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -840,7 +840,7 @@ let test_unikernels =
 
 let dec_b64_unik data =
   let data = Base64.decode_exn data in
-  Result.get_ok (Vmm_asn.unikernels_of_str data)
+  fst (Result.get_ok (Vmm_asn.state_of_str data))
 
 let u1_3 =
   Unikernel.{


### PR DESCRIPTION
The purpose is, while developing mollymawk - we discovered that the policies are ephemeral - thus if you have some unikernels dumped on disk, and (re)start albatross, they will be created (great!), but a policy_info command will return nothing. The issue is that in mollymawk we don't want to duplicate the storage effort, but rely on having the policy(ies) available - to generate intermediate certificates that are nice.

To describe it a bit more technical:
 albatross is running a bunch of unikernels, deployed via TLS
 albatross is stopped
 albatross is started, unikernels are restarted
 mollymawk is started and retrieves the policies from albatross
   <- here, we read before this commit the empty set
 mollymawk tries to do something, and needs to create an intermediate
  certificate -- and by default pushes a VM=0, mem=0 policy
  <- here, all goes to hell. this is what we like to avoid

Still, mollymawk is a bit special, since it reads the policies only on startup. This means an albatross with command-line policy modifications won't be updated in mollymawk. I guess the path forward is to notice that and make mollymawk the source of truth for policies (i.e. allow people to extract certificates for command line usage, provide the CA facility).