### PR TITLE
albatross_daemon: discover root policy and insert this

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -14,4 +14,8 @@
  (wrapped false)
  (modules vmm_unix vmm_lwt vmm_vmmd)
  (libraries albatross ipaddr.unix bos solo5-elftool lwt lwt.unix ptime.clock.os
-   digestif))
+   digestif)
+ (foreign_stubs
+  (language c)
+  (names vmm_stubs)
+  (flags (:standard))))

--- a/src/vmm_stubs.c
+++ b/src/vmm_stubs.c
@@ -15,18 +15,26 @@ CAMLprim value vmm_cpu_count (value unit) {
   CAMLreturn(Val_int(r));
 }
 
-int to_mb (int a, int b) {
+int to_mb (long a, long b) {
   int r = 0;
-  if (a % 1024 == 0) {
-    if (b % 1024 == 0)
-      r = (a / 1024) * (b / 1024);
-    else
-      r = (a / 1024) * b / 1024;
-  } else {
-    if (b % 1024 == 0)
-      r = a * (b / 1024) / 1024;
-    else
-      r = a * b / 1024 / 1024;
+  if (a % (1024 * 1024) == 0)
+    r = (a / 1024 / 1024) * b;
+  else {
+    if (b % (1024 * 1024) == 0)
+      r = a * (b / 1024 / 1024);
+    else {
+      if (a % 1024 == 0) {
+        if (b % 1024 == 0)
+          r = (a / 1024) * (b / 1024);
+        else
+          r = (a / 1024) * b / 1024;
+      } else {
+        if (b % 1024 == 0)
+          r = a * (b / 1024) / 1024;
+        else
+          r = a * b / 1024 / 1024;
+      }
+    }
   }
   return r;
 }

--- a/src/vmm_stubs.c
+++ b/src/vmm_stubs.c
@@ -11,7 +11,7 @@
 CAMLprim value vmm_cpu_count (value unit) {
   CAMLparam1(unit);
   int r;
-  r = (int)sysconf(_SC_NPROCESSORS_CONF);
+  r = (int)sysconf(_SC_NPROCESSORS_ONLN);
   CAMLreturn(Val_int(r));
 }
 

--- a/src/vmm_stubs.c
+++ b/src/vmm_stubs.c
@@ -1,0 +1,40 @@
+// (c) 2017, 2018 Hannes Mehnert, all rights reserved
+
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+#include <unistd.h>
+
+CAMLprim value vmm_cpu_count (value unit) {
+  CAMLparam1(unit);
+  int r;
+  r = (int)sysconf(_SC_NPROCESSORS_CONF);
+  CAMLreturn(Val_int(r));
+}
+
+CAMLprim value vmm_memory (value unit) {
+  CAMLparam1(unit);
+  long pages = sysconf(_SC_PHYS_PAGES);
+  long page_size = sysconf(_SC_PAGE_SIZE);
+  CAMLreturn(Val_int(pages * (page_size / 1024) / 1024));
+}
+
+#ifdef __linux__
+#include <sys/vfs.h>
+#else
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
+
+CAMLprim value vmm_disk_space (value path) {
+  CAMLparam1(path);
+  struct statfs s;
+  const char *p = String_val(path);
+  if (statfs(p, &s) < 0)
+    uerror("statfs", Nothing);
+  CAMLreturn(Val_int(s.f_blocks * s.f_bsize / 1024 / 1024));
+}
+

--- a/src/vmm_stubs.c
+++ b/src/vmm_stubs.c
@@ -15,11 +15,27 @@ CAMLprim value vmm_cpu_count (value unit) {
   CAMLreturn(Val_int(r));
 }
 
+int to_mb (int a, int b) {
+  int r = 0;
+  if (a % 1024 == 0) {
+    if (b % 1024 == 0)
+      r = (a / 1024) * (b / 1024);
+    else
+      r = (a / 1024) * b / 1024;
+  } else {
+    if (b % 1024 == 0)
+      r = a * (b / 1024) / 1024;
+    else
+      r = a * b / 1024 / 1024;
+  }
+  return r;
+}
+
 CAMLprim value vmm_memory (value unit) {
   CAMLparam1(unit);
   long pages = sysconf(_SC_PHYS_PAGES);
   long page_size = sysconf(_SC_PAGE_SIZE);
-  CAMLreturn(Val_int(pages * (page_size / 1024) / 1024));
+  CAMLreturn(Val_int(to_mb(pages, page_size)));
 }
 
 #ifdef __linux__
@@ -35,6 +51,6 @@ CAMLprim value vmm_disk_space (value path) {
   const char *p = String_val(path);
   if (statfs(p, &s) < 0)
     uerror("statfs", Nothing);
-  CAMLreturn(Val_int(s.f_blocks * s.f_bsize / 1024 / 1024));
+  CAMLreturn(Val_int(to_mb(s.f_blocks, s.f_bsize)));
 }
 

--- a/src/vmm_stubs.c
+++ b/src/vmm_stubs.c
@@ -7,6 +7,7 @@
 #include <caml/unixsupport.h>
 
 #include <unistd.h>
+#include <errno.h>
 
 CAMLprim value vmm_cpu_count (value unit) {
   CAMLparam1(unit);
@@ -59,6 +60,11 @@ CAMLprim value vmm_disk_space (value path) {
   const char *p = String_val(path);
   if (statfs(p, &s) < 0)
     uerror("statfs", Nothing);
+  int r = to_mb(s.f_blocks, s.f_bsize);
+  if (r < 0) {
+    errno = EOVERFLOW;
+    uerror("statfs", Nothing);
+  }
   CAMLreturn(Val_int(to_mb(s.f_blocks, s.f_bsize)));
 }
 

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -43,3 +43,5 @@ val vm_device : Unikernel.t -> (string, [> `Msg of string ]) result
 val manifest_devices_match : bridges:(string * string option * Macaddr.t option) list ->
   block_devices:(string * string option * int option) list -> string ->
   (unit, [> `Msg of string]) result
+
+val root_policy : unit -> (Policy.t, [> `Msg of string ]) result


### PR DESCRIPTION
Previously, there was no such thing. Now, to be able to avoid overcommitment, we discover the available cpus, memory, block device size, and bridges at startup. This results in some changed semantics:
- if a bridge used by some policy is not configured, we bail early
- if the policies lead to overcommitment, we bail early

We discover the root policy at startup each time (and also compare to the previous one), since we want to discover the data of the current system. It may be different from the previous one (network bridges, available memory, ...).

//cc @PizieDust (also happy to get a review from @reynir)