### PR TITLE
stats: /proc/pid/status parsing more flexible

### DIFF
--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -120,13 +120,9 @@ let read_proc_status pid =
     List.map (String.split_on_char ':') lines |>
     List.fold_left (fun acc x -> match acc, x with
         | Some acc, k :: v ->
-          (* strip leading tab character *)
-          let v = String.concat ":" v in
-          if String.length v > 1 then
-            let v = String.sub v 1 (String.length v - 1) in
-            Some ((k, v) :: acc)
-          else
-            None
+          (* strip leading tab character and further possible whitespace *)
+          let v = String.concat ":" v |> String.trim in
+          Some ((k, v) :: acc)
         | _ -> None) (Some []) |>
     Option.to_result ~none:(`Msg "failed to parse /proc/<pid>/status")
   with _ -> Error (`Msg (Fmt.str "error reading file /proc/%d/status" pid))


### PR DESCRIPTION
`/proc/<pid>/status` can have empty values, which were refused by the parsing function. For example on my machine (the separating tabs are still present):
```
x86_Thread_features:	
x86_Thread_features_locked:	
```

Furthermore, and even though no values other than `non/voluntary_ctxt_switches` are used for now, other lines have further leading whitespace (seemingly to align values for humans to read), like `VmPeak`.

Swap to using `String.trim` instead of doing it manually, accounting for all cases