### PR TITLE
On solo5 manifest mismatch print the manifest

### DIFF
--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -252,13 +252,12 @@ let check_solo5_tender target version =
     Error (`Msg (Fmt.str "unexpected solo5 tender --version output, expected one line with 'ABI version %u', got %s"
                    version (String.concat "\n" out)))
 
-let solo5_image_devices image =
-  let* mft = Solo5_elftool.query_manifest (owee_buf_of_str image) in
-  Ok (List.fold_left
-        (fun (block_devices, networks) -> function
-           | Solo5_elftool.Dev_block_basic name -> name :: block_devices, networks
-           | Solo5_elftool.Dev_net_basic name -> block_devices, name :: networks)
-        ([], []) mft.entries)
+let solo5_image_devices mft =
+  List.fold_left
+    (fun (block_devices, networks) -> function
+       | Solo5_elftool.Dev_block_basic name -> name :: block_devices, networks
+       | Solo5_elftool.Dev_net_basic name -> block_devices, name :: networks)
+    ([], []) mft.Solo5_elftool.entries
 
 let equal_string_lists b1 b2 err =
   if String_set.(equal (of_list b1) (of_list b2)) then
@@ -266,20 +265,23 @@ let equal_string_lists b1 b2 err =
   else
     Error (`Msg err)
 
-let devices_match ~bridges ~block_devices (manifest_block, manifest_net) =
+let devices_match ~bridges ~block_devices mft =
+  let (manifest_block, manifest_net) = solo5_image_devices mft in
   let* () =
     equal_string_lists manifest_block block_devices
-      "specified block device(s) does not match with manifest"
+      (Format.asprintf "specified block device(s) does not match with manifest. Declared manifest: %a"
+         Solo5_elftool.pp_mft mft)
   in
   equal_string_lists manifest_net bridges
-    "specified bridge(s) does not match with the manifest"
+    (Format.asprintf "specified bridge(s) does not match with the manifest. Declared manifest: %a"
+         Solo5_elftool.pp_mft mft)
 
 let manifest_devices_match ~bridges ~block_devices image =
-  let* things = solo5_image_devices image in
+  let* mft = Solo5_elftool.query_manifest (owee_buf_of_str image) in
   let bridges = List.map (fun (b, _, _) -> b) bridges
   and block_devices = List.map (fun (b, _, _) -> b) block_devices
   in
-  devices_match ~bridges ~block_devices things
+  devices_match ~bridges ~block_devices mft
 
 let bridge_name (service, b, _mac) = match b with None -> service | Some b -> b
 


### PR DESCRIPTION
This makes it easier for users of the client to figure out what devices are expected without them having to know to query the solo5 manifest using solo5-elftool themselves. I personally often either get the expected devices wrong or simply don't remember. In that case albatross-client can be a bit more helpful and display the information we have.

The output looks like the following (the indendation is a bit odd):
```
$ albatross-client create teeeest ~/workspace/./dnsvizor/dns-only/dist/dns-stub.hvt
albatross-client: specified bridge(s) does not match with the manifest. Declared manifest: {
                   "type": "solo5.manifest", "version": 1,
                   "devices": [ { "name": "service", "type": "NET_BASIC" } ]
                  }
```

If there's a mismatch of block devices the error message will not say anything about network devices. I'm okay with that.