### PR TITLE
Make restart command actually kill first

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -375,6 +375,11 @@ let handle_unikernel_cmd t id = function
       match Vmm_resources.find_unikernel t.resources id with
       | None -> stop_create t id
       | Some unikernel ->
+        let* resources = Vmm_resources.remove_unikernel t.resources id in
+        let* () = Vmm_resources.check_unikernel resources id unikernel.Unikernel.config in
+        (match Vmm_unix.destroy unikernel with
+         | exception Unix.Unix_error _ -> ()
+         | () -> ());
         Ok (t, `Wait_and_create (id, (id, unikernel.Unikernel.config)))
     end
   | `Unikernel_destroy ->


### PR DESCRIPTION
Otherwise it just waits until the VM exits for other reasons.

I found that `albatross-client restart` didn't work for our tlstunnel instance when it's stuck at 100% cpu, I then tested the following unikernels:
catch-fire:
```OCaml
module Make (_ : module type of Unit) = struct
  let rec start () = start ()
end
```
halt:
```OCaml
module Make (_ : module type of Unit) = struct
  let start () =
    fst (Lwt.task ())
end
```

The former does a CPU burn while the latter sleeps indefinitely. It turned out this did not matter.

I found that on a restart command we never actually kill the existing instance. So I looked at what is done for `` `Unikernel_force_create `` and adapted that.

I'm not convinced about the `None` case where we don't find a running instance. I need to study that code some more.