### PR TITLE
albatross-tls-endpoint: allow the unikernel image of unikernel_create to be the TLS payload

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -245,6 +245,7 @@ let policy unikernels memory cpus block bridgesl =
 
 let to_exit_code = function
   | Error `Eof -> Error Success
+  | Error `Tls_eof -> Error Success
   | Error _ -> Error Communication_failed
   | Ok wire -> output_result wire
 

--- a/daemon/albatross_tls_endpoint.ml
+++ b/daemon/albatross_tls_endpoint.ml
@@ -84,6 +84,22 @@ let handle tls =
                Lwt.fail_with "error retrieving unikernel image"
            else
              Lwt.return cmd
+         | `Block_cmd (`Block_add (size, compressed, Some "")) ->
+           begin
+             read_image tls >>= function
+             | Ok data ->
+               Lwt.return (`Block_cmd (`Block_add (size, compressed, Some data)))
+             | Error _ ->
+               Lwt.fail_with "error retrieving block data"
+           end
+         | `Block_cmd (`Block_set (compressed, "")) ->
+           begin
+             read_image tls >>= function
+             | Ok data ->
+               Lwt.return (`Block_cmd (`Block_set (compressed, data)))
+             | Error _ ->
+               Lwt.fail_with "error retrieving block data"
+           end
          | _ -> Lwt.return cmd) >>= fun cmd ->
         let sock, next = Vmm_commands.endpoint cmd in
         let sockaddr = Lwt_unix.ADDR_UNIX (Vmm_core.socket_path sock) in

--- a/tls/vmm_tls_lwt.ml
+++ b/tls/vmm_tls_lwt.ml
@@ -2,7 +2,7 @@
 
 open Lwt.Infix
 
-let read_tls t =
+let read_tls_chunk t =
   let rec r_n buf off tot =
     let l = tot - off in
     if l = 0 then
@@ -31,18 +31,24 @@ let read_tls t =
         (*          Logs.debug (fun m -> m "TLS read id %d %a tag %d data %a"
                          hdr.Vmm_wire.id Vmm_wire.pp_version hdr.Vmm_wire.version hdr.Vmm_wire.tag
                          (Ohex.pp_hexdump ()) b) ; *)
-        match Vmm_asn.wire_of_str (Bytes.unsafe_to_string b) with
-        | Error (`Msg msg) ->
-          Logs.err (fun m -> m "error %s while parsing data" msg) ;
-          Error `Exception
-        | (Ok (hdr, _)) as w ->
-          if not Vmm_commands.(is_current hdr.version) then
-            Logs.warn (fun m -> m "version mismatch, received %a current %a"
-                          Vmm_commands.pp_version hdr.Vmm_commands.version
-                          Vmm_commands.pp_version Vmm_commands.current);
-          w
-      else
-        Lwt.return (Error `Eof)
+        Ok (Bytes.unsafe_to_string b)
+    else
+      Lwt.return (Error `Eof)
+
+let read_tls t =
+  read_tls_chunk t >|= function
+  | Error _ as e -> e
+  | Ok data ->
+    match Vmm_asn.wire_of_str data with
+    | Error (`Msg msg) ->
+      Logs.err (fun m -> m "error %s while parsing data" msg) ;
+      Error `Exception
+    | (Ok (hdr, _)) as w ->
+      if not Vmm_commands.(is_current hdr.version) then
+        Logs.warn (fun m -> m "version mismatch, received %a current %a"
+                      Vmm_commands.pp_version hdr.Vmm_commands.version
+                      Vmm_commands.pp_version Vmm_commands.current);
+      w
 
 let write_tls s wire =
   let data = Vmm_asn.wire_to_str wire in

--- a/tls/vmm_tls_lwt.ml
+++ b/tls/vmm_tls_lwt.ml
@@ -11,7 +11,7 @@ let read_tls_chunk t =
       Tls_lwt.Unix.read t ~off buf >>= function
       | 0 ->
         Logs.debug (fun m -> m "TLS: end of file") ;
-        Lwt.return (Error `Eof)
+        Lwt.return (Error `Tls_eof)
       | x when x == l -> Lwt.return (Ok ())
       | x when x < l -> r_n buf (off + x) tot
       | _ ->

--- a/tls/vmm_tls_lwt.mli
+++ b/tls/vmm_tls_lwt.mli
@@ -1,10 +1,10 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 val read_tls_chunk : Tls_lwt.Unix.t ->
-  (string, [> `Eof | `Exception | `Toomuch ]) result Lwt.t
+  (string, [> `Eof | `Tls_eof | `Exception | `Toomuch ]) result Lwt.t
 
 val read_tls : Tls_lwt.Unix.t ->
-  (Vmm_commands.wire, [> `Eof | `Exception | `Toomuch ]) result Lwt.t
+  (Vmm_commands.wire, [> `Eof | `Tls_eof | `Exception | `Toomuch ]) result Lwt.t
 
 val write_tls :
   Tls_lwt.Unix.t -> Vmm_commands.wire -> (unit, [> `Exception ]) result Lwt.t

--- a/tls/vmm_tls_lwt.mli
+++ b/tls/vmm_tls_lwt.mli
@@ -1,5 +1,8 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
+val read_tls_chunk : Tls_lwt.Unix.t ->
+  (string, [> `Eof | `Exception | `Toomuch ]) result Lwt.t
+
 val read_tls : Tls_lwt.Unix.t ->
   (Vmm_commands.wire, [> `Eof | `Exception | `Toomuch ]) result Lwt.t
 


### PR DESCRIPTION
this is step 1 for streaming, and it does not stream from the tls endpoint to albatross -- the main issue is mollymawk, so let's have that stream the user input (or remote image) to albatross -- and albatross for now use the full unikernel image.

I guess with this change we can adapt mollymawk to stream the unikernel image instead of having it completely in memory. //cc @reynir @PizieDust https://github.com/robur-coop/mollymawk/issues/73