### PR TITLE
Thread state in client

### DIFF
--- a/daemon/albatross_tls_endpoint.ml
+++ b/daemon/albatross_tls_endpoint.ml
@@ -145,8 +145,8 @@ let handle tls =
               `Failure "couldn't write unikernel to VMMD"
             | Ok () ->
               (match next with
-               | `Read -> read version fd tls
-               | `End -> process fd) >>= fun res ->
+               | `Read | `Dump -> read version fd tls
+               | `Single -> process fd) >>= fun res ->
               Vmm_lwt.safe_close fd >|= fun () ->
               res
       end >>= fun reply ->

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -225,10 +225,10 @@ let pp_wire ~verbose ppf (header, data) =
   | `Data d -> pp_data ppf d
 
 let endpoint = function
-  | `Unikernel_cmd _ -> `Vmmd, `End
-  | `Policy_cmd _ -> `Vmmd, `End
-  | `Block_cmd `Block_dump _ -> `Vmmd, `Read
-  | `Block_cmd _ -> `Vmmd, `End
+  | `Unikernel_cmd _ -> `Vmmd, `Single
+  | `Policy_cmd _ -> `Vmmd, `Single
+  | `Block_cmd `Block_dump _ -> `Vmmd, `Dump
+  | `Block_cmd _ -> `Vmmd, `Single
   | `Stats_cmd `Stats_subscribe -> `Stats, `Read
-  | `Stats_cmd _ -> `Stats, `End
+  | `Stats_cmd _ -> `Stats, `Single
   | `Console_cmd _ -> `Console, `Read

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -109,4 +109,4 @@ type wire = header * res
 
 val pp_wire : verbose:bool -> wire Fmt.t
 
-val endpoint : t -> service * [ `End | `Read ]
+val endpoint : t -> service * [ `Single | `Read | `Dump ]


### PR DESCRIPTION
This threads state in the client so we can have an open file descriptor to dump a block device to. It also makes the protocol slightly more strict in the client. We could make it even more strict.

This lacks safeguards to close the `` `Dump_to fd `` file descriptor in case of errors.

I'm not sure I like this change.