### PR TITLE
albatross-client: fix console reading, do not close the connection immediately

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -96,7 +96,7 @@ let output_result state ((hdr, reply) as wire) =
         let name = hdr.Vmm_commands.name in
         write_to_file name compressed image;
         Lwt.return (Ok `End)
-      | _ -> Lwt.return (Ok `End)
+      | _ -> Lwt.return (Ok state)
     end
   | `Data `Block_data None ->
     (match state with


### PR DESCRIPTION
we receive a `` `sucess `` and then expect actual console data to flow over the connection. if the client closes the connection after receiving the success, we never see console data.