### PR TITLE
add "startup" to the unikernel config, the lowest is started first

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -96,8 +96,9 @@ let output_result state ((hdr, reply) as wire) =
         let name = hdr.Vmm_commands.name in
         write_to_file name compressed image;
         Lwt.return (Ok `End)
-      | `Block_devices _ | `Empty | `String _ | `Old_unikernel_info3 _
-      | `Old_unikernel_info2 _ | `Unikernel_info _ | `Policies _ ->
+      | `Empty | `String _ | `Block_devices _ | `Old_unikernel_info2 _
+      | `Old_unikernel_info3 _ | `Old_unikernel_info4 _ | `Unikernel_info _
+      | `Policies _ ->
         begin match state with
           | `Single | `End -> Lwt.return (Ok `End)
           | `Dump | `Dump_to _ | `Read as state ->

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -65,6 +65,7 @@ type unikernel_cmd = [
   | `Old_unikernel_info1
   | `Old_unikernel_info2
   | `Old_unikernel_info3
+  | `Old_unikernel_info4
   | `Old_unikernel_get
 ]
 
@@ -87,6 +88,7 @@ let pp_unikernel_cmd ~verbose ppf = function
   | `Old_unikernel_info1 -> Fmt.string ppf "old unikernel info1"
   | `Old_unikernel_info2 -> Fmt.string ppf "old unikernel info2"
   | `Old_unikernel_info3 -> Fmt.string ppf "old unikernel info3"
+  | `Old_unikernel_info4 -> Fmt.string ppf "old unikernel info4"
   | `Old_unikernel_get -> Fmt.string ppf "old unikernel get"
 
 type policy_cmd = [
@@ -172,13 +174,14 @@ type success = [
   | `String of string
   | `Policies of (Name.t * Policy.t) list
   | `Old_unikernels of (Name.t * Unikernel.config) list
-  | `Unikernel_info of (Name.t * Unikernel.info) list
+  | `Old_unikernel_info4 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info2 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info3 of (Name.t * Unikernel.info) list
   | `Unikernel_image of bool * string
   | `Block_devices of (Name.t * int * bool) list
   | `Old_block_device_image of bool * string
   | `Block_device_image of bool
+  | `Unikernel_info of (Name.t * Unikernel.info) list
 ]
 
 let pp_block ppf (id, size, active) =
@@ -199,7 +202,7 @@ let pp_success ~verbose ppf = function
       Fmt.(pair ~sep:(any ": ") Name.pp
              (if verbose then Unikernel.pp_config_with_argv else Unikernel.pp_config))
       ppf unikernels
-  | `Unikernel_info infos | `Old_unikernel_info2 infos | `Old_unikernel_info3 infos ->
+  | `Unikernel_info infos | `Old_unikernel_info2 infos | `Old_unikernel_info3 infos | `Old_unikernel_info4 infos ->
     my_fmt_list "no unikernels"
       Fmt.(pair ~sep:(any ": ") Name.pp
              (if verbose then Unikernel.pp_info_with_argv else Unikernel.pp_info))

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -40,6 +40,7 @@ type unikernel_cmd = [
   | `Old_unikernel_info1
   | `Old_unikernel_info2
   | `Old_unikernel_info3
+  | `Old_unikernel_info4
   | `Old_unikernel_get
 ]
 
@@ -94,6 +95,7 @@ type success = [
   | `Old_unikernels of (Name.t * Unikernel.config) list
   | `Old_unikernel_info2 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info3 of (Name.t * Unikernel.info) list
+  | `Old_unikernel_info4 of (Name.t * Unikernel.info) list
   | `Unikernel_info of (Name.t * Unikernel.info) list
   | `Unikernel_image of bool * string
   | `Block_devices of (Name.t * int * bool) list

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -106,6 +106,7 @@ module Unikernel : sig
     compressed : bool ;
     image : string  ;
     fail_behaviour : fail_behaviour;
+    startup : int option ;
     cpuid : int ;
     memory : int ;
     block_devices : (string * string option * int option) list ;
@@ -163,6 +164,7 @@ module Unikernel : sig
   type info = {
     typ : typ ;
     fail_behaviour : fail_behaviour;
+    startup : int option ;
     cpuid : int ;
     memory : int ;
     block_devices : block_info list ;

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -337,6 +337,18 @@ let handle_unikernel_cmd t id =
           (Vmm_trie.find id t.resources.Vmm_resources.unikernels)
     in
     Ok (t, `End (`Success (`Old_unikernel_info3 infos)))
+  | `Old_unikernel_info4 ->
+    Logs.debug (fun m -> m "info %a" Name.pp id) ;
+    let infos =
+      match Name.name id with
+      | None ->
+        Vmm_trie.fold (Name.path id) t.resources.Vmm_resources.unikernels
+          (fun id unikernel unikernels -> (id, Unikernel.info (block_size id) unikernel) :: unikernels) []
+      | Some _ ->
+        Option.fold ~none:[] ~some:(fun unikernel -> [ id, Unikernel.info (block_size id) unikernel ])
+          (Vmm_trie.find id t.resources.Vmm_resources.unikernels)
+    in
+    Ok (t, `End (`Success (`Old_unikernel_info4 infos)))
   | `Unikernel_info ->
     Logs.debug (fun m -> m "info %a" Name.pp id) ;
     let infos =

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -3,7 +3,7 @@
 let u1 =
   Vmm_core.Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "";
-    fail_behaviour = `Quit ; cpuid = 0 ; memory = 1 ;
+    fail_behaviour = `Quit ; startup = None ; cpuid = 0 ; memory = 1 ;
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -12,7 +12,7 @@ let u1 =
 let u2 =
   Vmm_core.Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "";
-    fail_behaviour = `Quit ; cpuid = 2 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; cpuid = 2 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] ;
     argv = None ;

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -286,7 +286,7 @@ let test_resources =
 let u =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; cpuid = 0 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; cpuid = 0 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", None, None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -845,7 +845,7 @@ let dec_b64_unik data =
 let u1_3 =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; cpuid = 0 ; memory = 1 ;
+    fail_behaviour = `Quit ; startup = None ; cpuid = 0 ; memory = 1 ;
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -854,7 +854,7 @@ let u1_3 =
 let u2_3 =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; cpuid = 2 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; cpuid = 2 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", None ] ;
     argv = None ;


### PR DESCRIPTION
this addresses #53

Please note, since we use "optional" in the ASN.1 at a place where it is not ambiguous, we don't need to revise the wire format. If we'd have put it before/after another "int" field, it would be ambiguous.